### PR TITLE
add showPaymentMethod defaults to db init script

### DIFF
--- a/server/utilities/databaseInitialiser.js
+++ b/server/utilities/databaseInitialiser.js
@@ -24,6 +24,8 @@ module.exports = co.wrap(function* initialise() {
         aboutOurHoneymoon: comingSoonText,
         honeymoonGiftList: {
             content: comingSoonText,
+            showPaymentMessage: comingSoonText,
+            paymentMessage: false,
             showOfflinePaymentMessage: false,
             offlinePaymentMessage: comingSoonText,
             showDisclaimerMessage: false,


### PR DESCRIPTION
 `server/utilities/databaseInitialiser.js` was missing mock objects for `showPaymentMessage` & `paymentMessage` and would subsequently fail mongoose validation, preventing the creation of new mongo dbs.
